### PR TITLE
Default token to environment variable of GITHUB_TOKEN

### DIFF
--- a/fetch-code-review-metrics.py
+++ b/fetch-code-review-metrics.py
@@ -139,6 +139,9 @@ def main():
     # Read arguments from command line
     args = parser.parse_args()
 
+    if not args.token:
+        parser.error(f"argument -t/--token: token value is unset")
+
     queryOpts = {
         "repo": args.repo,
         "org": args.org

--- a/fetch-code-review-metrics.py
+++ b/fetch-code-review-metrics.py
@@ -2,6 +2,7 @@
 
 from dateutil.parser import parse
 import argparse
+import os
 import requests
 
 import csv
@@ -132,7 +133,7 @@ def main():
     parser.add_argument("-o", "--org", help = "The orginization to grab pull request metrics from")
     parser.add_argument("-r", "--repo", help = "The repository to grab pull request metrics from")
     parser.add_argument("-q", "--query", help="The query to search for pull requests. See more at <> . This overrides whatever was set via '-r' or '--repo'")
-    parser.add_argument("-t", "--token", help = "A GitHub token to access the GitHub API")
+    parser.add_argument("-t", "--token", default=os.getenv("GITHUB_TOKEN"), help="A GitHub token to access the GitHub API")
     parser.add_argument("-f", "--file", help = "The path to the csv file to generate")
 
     # Read arguments from command line


### PR DESCRIPTION
This removes the need to pass a secret as a CLI argument. The token is fetched from the environment variable of GITHUB_TOKEN by default.

Fixes: #2